### PR TITLE
Feature/add url to google tag manager

### DIFF
--- a/docs/02-app/01-building-your-application/06-optimizing/12-third-party-libraries.mdx
+++ b/docs/02-app/01-building-your-application/06-optimizing/12-third-party-libraries.mdx
@@ -116,6 +116,16 @@ export default function Page() {
 ```
 
 </PagesOnly>
+#### Using a custom server URL
+
+If you have a server-side tag manager deployment, you can customize the URL by passing in a `url` parameter. The component uses `https://www.googletagamanager.com` by default.
+
+```jsx
+import { GoogleTagManager } from '@next/third-parties/google'
+
+  <GoogleTagManager gtmId="GTM-XYZ" url="https://tag-manager-server.xyz" />
+}
+```
 
 #### Sending Events
 

--- a/packages/third-parties/src/google/gtm.tsx
+++ b/packages/third-parties/src/google/gtm.tsx
@@ -8,7 +8,7 @@ import type { GTMParams } from '../types/google'
 let currDataLayerName: string | undefined = undefined
 
 export function GoogleTagManager(props: GTMParams) {
-  const { gtmId, dataLayerName = 'dataLayer', auth, preview, dataLayer } = props
+  const { gtmId, dataLayerName = 'dataLayer', auth, preview, dataLayer, url } = props
 
   if (currDataLayerName === undefined) {
     currDataLayerName = dataLayerName
@@ -17,7 +17,7 @@ export function GoogleTagManager(props: GTMParams) {
   const gtmLayer = dataLayerName !== 'dataLayer' ? `&l=${dataLayerName}` : ''
   const gtmAuth = auth ? `&gtm_auth=${auth}` : ''
   const gtmPreview = preview ? `&gtm_preview=${preview}&gtm_cookies_win=x` : ''
-
+  const gtmUrl = url ? url : 'https://www.googletagmanager.com'
   useEffect(() => {
     // performance.mark is being used as a feature use signal. While it is traditionally used for performance
     // benchmarking it is low overhead and thus considered safe to use in production and it is a widely available
@@ -47,7 +47,7 @@ export function GoogleTagManager(props: GTMParams) {
       <Script
         id="_next-gtm"
         data-ntpc="GTM"
-        src={`https://www.googletagmanager.com/gtm.js?id=${gtmId}${gtmLayer}${gtmAuth}${gtmPreview}`}
+        src={`${gtmUrl}/gtm.js?id=${gtmId}${gtmLayer}${gtmAuth}${gtmPreview}`}
       />
     </>
   )

--- a/packages/third-parties/src/types/google.ts
+++ b/packages/third-parties/src/types/google.ts
@@ -11,6 +11,7 @@ export type GTMParams = {
   dataLayerName?: string
   auth?: string
   preview?: string
+  url?: string
 }
 
 export type GAParams = {


### PR DESCRIPTION
<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->
From my seat it looks like two very simple changes, entirely non-breaking:

1. Update `GTMParams` type: 

In the /packages/third-parties/src/types/google.ts file add an optional `url` parameter to `GTMParams`. 

```ts
export type GTMParams = {
  gtmId: string
  dataLayer?: string[]
  dataLayerName?: string
  auth?: string
  preview?: string
  url?: string // new
}
```

2. Update the /packages/third-parties/src/google/gtm.tsx file add the `url` parameter _only if_ it is included:

```tsx
  const { gtmId, dataLayerName = 'dataLayer', auth, preview, dataLayer, url } = props
  const gtmLayer = dataLayerName !== 'dataLayer' ? `&l=${dataLayerName}` : ''
  const gtmAuth = auth ? `&gtm_auth=${auth}` : ''
  const gtmPreview = preview ? `&gtm_preview=${preview}&gtm_cookies_win=x` : ''
  const gtmUrl = url ? url : 'https://www.googletagmanager.com' // new

// second script component returned now uses gtmUrl which defaults to exactly the same url as was hardcoded before
      <Script
        id="_next-gtm"
        data-ntpc="GTM"
        src={`${gtmUrl}/gtm.js?id=${gtmId}${gtmLayer}${gtmAuth}${gtmPreview}`}
      />
```